### PR TITLE
新綠豆機制 & 討論版頁面顯示文章引言 & 修復 Safari 解鎖問題

### DIFF
--- a/wp-content/plugins/GoGet-custom-mycred-hook/GoGet-custom-mycred-hook.php
+++ b/wp-content/plugins/GoGet-custom-mycred-hook/GoGet-custom-mycred-hook.php
@@ -99,7 +99,7 @@ function mycredpro_load_goget_trashed_topic_hook() {
     		// Check if user is excluded (required)
     		if ( $this->core->exclude_user( $user_id ) ) return;
     		
-    		if (current_user_can('administrator')){
+    		if (mycred_is_admin(get_current_user_id())){
     		    $log = '文章「' . bbp_get_topic_title() . '」被管理員下架';
     		}else{
     		    $log = '刪除文章「' . bbp_get_topic_title() . '」';
@@ -111,7 +111,7 @@ function mycredpro_load_goget_trashed_topic_hook() {
     			$user_id,
     			-50,    // the amount of point deducted
     			$log,
-    			0,
+    			$topic_id,
     			'',
     			$m
     		);
@@ -188,7 +188,9 @@ function mycredpro_load_goget_create_topic_hook() {
     		// Check if user is excluded (required)
     		if ( $this->core->exclude_user( $user_id ) ) return;
     		
-            $log = '建立文章「' . bbp_get_topic_title($topic_id) . '」';
+    		$link_with_title = '<a href="' . bbp_get_topic_permalink($topic_id) . '">' . bbp_get_topic_title($topic_id) . '</a>';
+    		
+            $log = '建立文章 ' . $link_with_title;
             
     		// Execute
     		$this->core->add_creds(
@@ -196,8 +198,199 @@ function mycredpro_load_goget_create_topic_hook() {
     			$user_id,
     			50,    // the amount of point awarded
     			$log,
-    			0,
+    			$topic_id,
     			'',
+    			$m
+    		);
+		}
+	}
+}
+
+
+
+
+
+
+//////// POINT AWARD FOR SUBMITTING REVIEWS //////////
+// Award authors for submitting reviews
+// do_action('GoGet_star_review_new_review', $post_id, $rating_id, $rating, $current_user->ID) is called by plugins/rate-star-review/rate-star-review.php
+
+add_action( 'mycred_setup_hooks', 'goget_register_submit_review_hook' );
+function goget_register_submit_review_hook( $installed ) {
+
+	$installed['goget_point_award_for_submitting_review'] = array(
+		'title'       => __( '[GoGet] %plural% for submitting review', 'mycredcu' ),
+		'description' => __( 'Award users for submitting review', 'mycredcu' ),
+		'callback'    => array( 'myCRED_Hook_GoGet_Submit_Review' )
+	);
+	return $installed;
+}
+
+/**
+ * Custom Hook: Load custom hook
+ * Since 1.6, this would be the proper way to add in the hook class from a theme file
+ * or from a plugin file.
+ * @since 1.0
+ * @version 1.0
+ */
+add_action( 'mycred_load_hooks', 'mycredpro_load_goget_submit_review_hook', 10 );
+function mycredpro_load_goget_submit_review_hook() {
+
+	class myCRED_Hook_GoGet_Submit_Review extends myCRED_Hook {
+
+		/**
+		 * Construct
+		 */
+		function __construct( $hook_prefs, $type = 'mycred_default' ) {
+
+// id must start with lower case !!!!!!!
+			parent::__construct( array(
+				'id'       => 'goget_point_award_for_submitting_review',
+				'defaults' => array(
+				)
+			), $hook_prefs, $type );
+		}
+
+		/**
+		 * Run
+		 * @since 1.0
+		 * @version 1.0
+		 */
+		public function run() {
+
+			add_action( 'GoGet_star_review_new_review', array( $this, 'goget_point_award_for_submitting_review' ), 10, 4);
+
+		}
+
+		/**
+		 * @since 1.0
+		 * @version 1.0
+		 */
+		public function goget_point_award_for_submitting_review( $topic_id, $rating_id, $rating, $user_id ) {
+		    
+    		// Check if user is excluded (required)
+    		if ( $this->core->exclude_user( $user_id ) ) return;
+    		
+    		$link_with_title = '<a href="' . bbp_get_topic_permalink($topic_id) . '">' . bbp_get_topic_title($topic_id) . '</a>';
+    		
+            $log = '評論文章 ' . $link_with_title;
+            
+    		// Execute
+    		$this->core->add_creds(
+    			'goget_point_award_for_submitting_review',
+    			$user_id,
+    			3,    // the amount of point awarded
+    			$log,
+    			$topic_id,
+    		    array(
+    			    'rating_id' => $rating_id,
+    			    'rating' => $rating
+    		    ),
+    			$m
+    		);
+    		
+    		echo '<script type="text/javascript">location.reload(true);</script>'; // refresh page
+		}
+	}
+}
+
+
+
+
+
+
+
+//////// POINT AWARD FOR RECEIVING RATING //////////
+// Award authors for receiving ratings
+// do_action('GoGet_star_review_new_review', $post_id, $rating_id, $rating, $current_user->ID) is called by plugins/rate-star-review/rate-star-review.php
+// Important remark: The awarded points will not be changed even if the rating user changes the rating afterward. If we want to implement this, we have to create another hook for editing reviews
+
+add_action( 'mycred_setup_hooks', 'goget_register_receive_review_hook' );
+function goget_register_receive_review_hook( $installed ) {
+
+	$installed['goget_point_award_for_receiving_review'] = array(
+		'title'       => __( '[GoGet] %plural% for receiving review', 'mycredcu' ),
+		'description' => __( 'Award users for receiving review', 'mycredcu' ),
+		'callback'    => array( 'myCRED_Hook_GoGet_Receive_Review' )
+	);
+	return $installed;
+}
+
+/**
+ * Custom Hook: Load custom hook
+ * Since 1.6, this would be the proper way to add in the hook class from a theme file
+ * or from a plugin file.
+ * @since 1.0
+ * @version 1.0
+ */
+add_action( 'mycred_load_hooks', 'mycredpro_load_goget_receive_review_hook', 10 );
+function mycredpro_load_goget_receive_review_hook() {
+
+	class myCRED_Hook_GoGet_Receive_Review extends myCRED_Hook {
+
+		/**
+		 * Construct
+		 */
+		function __construct( $hook_prefs, $type = 'mycred_default' ) {
+
+// id must start with lower case !!!!!!!
+			parent::__construct( array(
+				'id'       => 'goget_point_award_for_receiving_review',
+				'defaults' => array(
+				)
+			), $hook_prefs, $type );
+		}
+
+		/**
+		 * Run
+		 * @since 1.0
+		 * @version 1.0
+		 */
+		public function run() {
+
+			add_action( 'GoGet_star_review_new_review', array( $this, 'goget_point_award_for_receiving_review' ), 9, 4);
+
+		}
+
+		/**
+		 * @since 1.0
+		 * @version 1.0
+		 */
+		public function goget_point_award_for_receiving_review( $topic_id, $rating_id, $rating, $user_id) {
+		    
+		    $author_id = bbp_get_topic_author_id($topic_id);
+
+    		// Check if user is excluded (required)
+    		if ( $this->core->exclude_user( $author_id ) ) return;
+
+    		if ($rating == 5) {
+    			$awarded_points = 3;
+    		}
+    		elseif ($rating == 4) {
+    			$awarded_points = 1;
+    		}
+    		else {
+    			$awarded_points = 0;
+    		}
+
+    		if ($awarded_points == 0) return;
+ 
+    		$link_with_title = '<a href="' . bbp_get_topic_permalink($topic_id) . '">' . bbp_get_topic_title($topic_id) . '</a>';
+
+            $log = '文章 ' . $link_with_title . ' 獲得' . $rating . '星評論';
+            
+    		// Execute
+    		$this->core->add_creds(
+    			'goget_point_award_for_receiving_review',
+                $author_id,
+    			$awarded_points,    // the amount of point awarded
+    			$log,
+    			$topic_id,
+    			array(
+    			    'reviewer' => $user_id,
+    			    'rating_id' => $rating_id,
+    			    'rating' => $rating
+    		    ),
     			$m
     		);
 		}

--- a/wp-content/plugins/GoGet-display-sell-count/GoGet-display-sell-count.php
+++ b/wp-content/plugins/GoGet-display-sell-count/GoGet-display-sell-count.php
@@ -16,22 +16,27 @@ function goget_display_sell_count(){
     }
     
     $topic_post_time_days_ago = (current_time('timestamp') - get_the_time("U")) / (86400);
-    $ture_sell_count = do_shortcode("[mycred_content_sale_count]");
-    if($topic_post_time_days_ago >= 10){
-        $display_sell_count = $ture_sell_count + 3;
-    }elseif($topic_post_time_days_ago >= 5){
-        $display_sell_count = $ture_sell_count + 2;
-    }elseif($topic_post_time_days_ago >= 1){
-        $display_sell_count = $ture_sell_count + 1;
-    }else{
-        $display_sell_count = $ture_sell_count;
-    }
-    $display = $display_sell_count == 0 ? "尚無人解鎖此文章
-    " : "" . $display_sell_count . "人已經解鎖此文章
+    // $ture_sell_count = do_shortcode("[mycred_content_sale_count]");
+    // if($topic_post_time_days_ago >= 10){
+    //     $display_sell_count = $ture_sell_count + 3;
+    // }elseif($topic_post_time_days_ago >= 5){
+    //     $display_sell_count = $ture_sell_count + 2;
+    // }elseif($topic_post_time_days_ago >= 1){
+    //     $display_sell_count = $ture_sell_count + 1;
+    // }else{
+    //     $display_sell_count = $ture_sell_count;
+    // }
+    // $display = $display_sell_count == 0 ? "尚無人解鎖此文章
+    // " : "" . $display_sell_count . "人已經解鎖此文章
+    // ";
+    // if(current_user_can('administrator')){
+    //     return $display . "(實際解鎖數:" . $ture_sell_count . ")";
+    // }else{
+    //     return $display;
+    // }
+
+    $sell_count = do_shortcode("[mycred_content_sale_count]");
+    return $sell_count == 0 ? "尚無人解鎖此文章
+    " : "" . $sell_count . "人已經解鎖此文章
     ";
-    if(current_user_can('administrator')){
-        return $display . "(實際解鎖數:" . $ture_sell_count . ")";
-    }else{
-        return $display;
-    }
 }

--- a/wp-content/plugins/andy-mycred-auto-set-topic-for-sale/andy-mycred-auto-set-topic-for-sale.php
+++ b/wp-content/plugins/andy-mycred-auto-set-topic-for-sale/andy-mycred-auto-set-topic-for-sale.php
@@ -8,6 +8,7 @@ Author URI:
 Version: 1.0.0
 */
 
+# set content for sale upon post creation
 add_action ( 'bbp_new_topic', 'set_topic_for_mycred_sale', 10, 1 );
 
 if ( ! function_exists( 'set_topic_for_mycred_sale' ) ) :
@@ -18,9 +19,27 @@ if ( ! function_exists( 'set_topic_for_mycred_sale' ) ) :
 	    } // for issue 49 end
         $sale_setup = array(
             'status' => 'enabled',
-            'price' => 10,
+            'price' => 5,
             'expire' => 0
             );
         mycred_update_post_meta($topic_id, 'myCRED_sell_content', $sale_setup);
+	}
+endif;
+
+
+# Increase price upon the 3rd purchase
+add_action ( 'GoGet_new_purchase', 'increase_content_price_if_needed', 10, 1 );
+
+if ( ! function_exists( 'increase_content_price_if_needed' ) ) :
+	function increase_content_price_if_needed($topic_id=0) {
+		$sell_count = $sell_count = mycred_get_content_sales_count($topic_id);
+		if ($sell_count == 3) {  # update price at the third purchase
+	        $sale_setup = array(
+	            'status' => 'enabled',
+	            'price' => 10,
+	            'expire' => 0
+	            );
+	        mycred_update_post_meta($topic_id, 'myCRED_sell_content', $sale_setup);
+        }
 	}
 endif;

--- a/wp-content/plugins/bbpress/templates/default/bbpress/loop-single-topic.php
+++ b/wp-content/plugins/bbpress/templates/default/bbpress/loop-single-topic.php
@@ -48,6 +48,25 @@ defined( 'ABSPATH' ) || exit;
 		<?php do_action( 'bbp_theme_before_topic_title' ); ?>
 
 		<a class="bbp-topic-permalink" href="<?php bbp_topic_permalink(); ?>"><?php bbp_topic_title(); ?></a>
+<!-- 在下面這邊加入判斷解鎖資訊 -->
+		<?php 
+			if(mycred_post_is_for_sale(bbp_get_topic_id() )&& mycred_get_content_sales_count(bbp_get_topic_id()) < 3){
+				echo('
+					<div class="watch-first"; ; style="display: inline-block; color: red ; padding: 4px ; border: 1px solid; text-align:center " >  搶先看！ </div>
+
+				');
+			}
+		
+		?>
+		
+		<?php
+		if (bbp_get_forum_id() == 70){ // 討論版
+    		$excerpt = get_the_excerpt(); 
+            $excerpt = substr( $excerpt, 0, 100 );
+            echo('<br>'. $excerpt);
+		}
+        ?>
+<!-- 在上面這邊加入判斷解鎖資訊 -->
 
 		<?php do_action( 'bbp_theme_after_topic_title' ); ?>
 
@@ -59,7 +78,17 @@ defined( 'ABSPATH' ) || exit;
 
 			<?php do_action( 'bbp_theme_before_topic_started_by' ); ?>
 
-			<span class="bbp-topic-started-by"><?php printf( esc_html__( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ) ) ); ?></span>
+			<span class="bbp-topic-started-by">
+				<?php 
+					printf( esc_html__( 'Started by: %1$s', 'bbpress' ), bbp_get_topic_author_link( array( 'size' => '14' ))
+				);
+
+
+				?>	
+				</span>
+
+
+
 
 			<?php do_action( 'bbp_theme_after_topic_started_by' ); ?>
 
@@ -81,16 +110,25 @@ defined( 'ABSPATH' ) || exit;
 	</li>
 
     <li class="bbp-topic-voice-count"><?php echo get_wpbbp_post_view( bbp_get_topic_id() ); ?>
+<!-- ===== -->
 
-	<li class="bbp-topic-reply-count"><?php echo ( bbp_show_lead_topic() ? bbp_get_topic_reply_count()-1 : bbp_get_topic_post_count()-1); ?></li>
+
+<li class="bbp-topic-reply-count">
+
+	<!-- topic reply count -->
+	<?php bbp_topic_reply_count() ?>
+
+	</li>
+
 
 	<li class="bbp-topic-freshness">
 
-		<?php do_action( 'bbp_theme_before_topic_freshness_link' ); ?>
+<!-- 控制顯示日期只有年/月 -->
+	<?php 
+		$post_date = bbp_get_topic_post_date();
+		echo("<div style='transform: translateX(10px)'>".substr($post_date,0,10)."</div>");
+	?>
 
-		<?php bbp_topic_freshness_link(); ?>
-
-		<?php do_action( 'bbp_theme_after_topic_freshness_link' ); ?>
 
 <!--		<p class="bbp-topic-meta">
 
@@ -102,4 +140,7 @@ defined( 'ABSPATH' ) || exit;
 
 		</p>-->
 	</li>
+<!-- ======== -->
 </ul><!-- #bbp-topic-<?php bbp_topic_id(); ?> -->
+
+

--- a/wp-content/plugins/mycred/addons/sell-content/includes/mycred-sell-functions.php
+++ b/wp-content/plugins/mycred/addons/sell-content/includes/mycred-sell-functions.php
@@ -482,7 +482,9 @@ if ( ! function_exists( 'mycred_sell_content_payment_buttons' ) ) :
                 
                 //Andy edited
                 $button   = '<button type="button" class="mycred-buy-this-content-button ' . $setup['button_classes'] . '" data-pid="' . $post_id . '" data-type="' . $point_type . '">' . $button_label . '</button>';
-                $buttons[]    = apply_filters( 'mycred_sell_this_button', $button, $post, $setup, $mycred );
+                
+				// $button       = '<button type="button" class="mycred-buy-this-content-button ' . $setup['button_classes'] . '" data-pid="' . $post_id . '" data-type="' . $point_type . '" onclick="javascript:self.location.reload()";>' . $button_label . '</button>';
+				$buttons[]    = apply_filters( 'mycred_sell_this_button', $button, $post, $setup, $mycred );
 
 			}
 
@@ -626,6 +628,7 @@ if ( ! function_exists( 'mycred_sell_content_new_purchase' ) ) :
 					mycred_delete_post_meta( $post->ID, '_mycred_content_sales' );
 					mycred_delete_post_meta( $post->ID, '_mycred_content_buyers' );
 
+					do_action('GoGet_new_purchase', $post->ID);
 				}
 
 				// Free

--- a/wp-content/plugins/rate-star-review/rate-star-review.php
+++ b/wp-content/plugins/rate-star-review/rate-star-review.php
@@ -90,8 +90,6 @@ if (!class_exists("VWrateStarReview"))
 					return  $content . $addCode;
 				}
 
-			return $content;
-
 		}
 
 		static function updatePostRating($post_id)
@@ -504,8 +502,10 @@ HTMLCODE;
 					'post_status'    => 'publish',
 				);
 
-				if ($form == 'insert' ) $rating_id = wp_insert_post($post);
-
+				if ($form == 'insert' ) {
+				    $rating_id = wp_insert_post($post);
+					do_action('GoGet_star_review_new_review', $post_id, $rating_id, $rating, $current_user->ID);
+				}
 
 				if ($form == 'update' )
 				{
@@ -617,13 +617,21 @@ HTMLCODE;
 			$htmlCode .= '<script>
 			function formVars(params)
 			{
-			var vars = params;
-			vars = vars + \'&rating=\' + jQuery(\'#rating\').rating(\'get rating\');
-			vars = vars + \'&title=\' + encodeURIComponent(jQuery(\'#reviewTitle\').val());
-			vars = vars + \'&content=\' + encodeURIComponent(jQuery(\'#reviewContent\').val());
-			vars = vars + \'&category=\' + encodeURIComponent(jQuery(\'#reviewCategory\').val());
+				//從這裡開始加入擋住空白元素的判斷式
+				if (jQuery(\'#reviewContent\').val()==""){
+					alert("請輸入評論喔~");
+					var form= document.getElementsByClassName("ui form")[0];
+					form.innerHTML= form.innerHTML + "<h5 style=" + "color:red" + " >請輸入評論喔~</h5>";
+				}else { 
 
-			return vars;
+
+				var vars = params;
+				vars = vars + \'&rating=\' + jQuery(\'#rating\').rating(\'get rating\');
+				vars = vars + \'&title=\' + encodeURIComponent(jQuery(\'#reviewTitle\').val());
+				vars = vars + \'&content=\' + encodeURIComponent(jQuery(\'#reviewContent\').val());
+				vars = vars + \'&category=\' + encodeURIComponent(jQuery(\'#reviewCategory\').val());
+				return vars;
+				}
 			}
 
 			</script>';
@@ -669,29 +677,29 @@ var loader$id;
 
 	function loadContent$id(message = '', vars = ''){
 
-	if (message)
-	if (message.length > 0)
-	{
-	  jQuery("#videowhisperContainer$id").html(message);
-	}
+		if (message)
+		if (message.length > 0)
+		{
+		jQuery("#videowhisperContainer$id").html(message);
+		}
 
-		if (loader$id) loader$id.abort();
+			if (loader$id) loader$id.abort();
 
-		loader$id = jQuery.ajax({
-			url: aurl$id,
-			data: "interfaceid=$id" + vars,
-			success: function(data) {
-				jQuery("#videowhisperContainer$id").html(data);
-				//jQuery('.ui.rating').rating();
-				jQuery('.ui.rating.readonly').rating('disable');
-			}
-		});
-	}
-
+			loader$id = jQuery.ajax({
+				url: aurl$id,
+				data: "interfaceid=$id" + vars,
+				success: function(data) {
+					jQuery("#videowhisperContainer$id").html(data);
+					//jQuery('.ui.rating').rating();
+					jQuery('.ui.rating.readonly').rating('disable');
+				}
+			});
+		}
+	
 	jQuery(document).ready(function(){
 		loadContent$id();
 	});
-
+	
 </script>
 
 <div id="videowhisperContainer$id" class="videowhisperContainer ui container">


### PR DESCRIPTION
## 新綠豆機制
### 備註
- 目前文章分享者刪除文章，只會收回寫文章的 50 顆，沒有收回因為獲得評價而獲得的綠豆，跟規格書不一樣 
- 新文章價格優惠無法溯及既往: 所有解鎖數小於3的文章，旁邊都會顯示「搶先看」的字樣，但是，該機制上線前po出的文章，即便解鎖數不到3，價格依然會是10顆綠豆。之後正式上線，需要手動把這些文章的價格改成5顆綠豆
- 上傳code後，還要去 網站後台 activate新實作的hook (Andy will do)
### Spec
[連結](https://docs.google.com/document/d/1poqEUce4NvdSRwaY_t8eBXHPXmKcNXTTXVdffwbj2ig/edit)

## 討論版頁面顯示文章引言
### 圖例
![image](https://user-images.githubusercontent.com/37827315/120931326-a28f1180-c723-11eb-862c-3842960aa23e.png)

## Safari文章解鎖問題
### 解決方法
- 原本用safari解鎖文章有時會fail，原因是GoGet在解鎖按鈕加上強制reload。後來發現myCred自己就有解鎖後reload的設定，採用myCred的設定後就好了
### 備註
- 上傳完後，記得到 網站後台 確認設定 (Andy will do)

