### PR TITLE
User 發文後無法再發新文章

### DIFF
--- a/wp-content/plugins/GoGet-forum/includes/post.php
+++ b/wp-content/plugins/GoGet-forum/includes/post.php
@@ -48,7 +48,7 @@ if (!function_exists('save_post')) :
                     $anonymous = $form_data[GOGETFORUMS_FORM_PREFIX . 'anonymous'] == '是';
 
                     // array("標題", "是否匿名", "標籤", "(已棄用)文章內容", "文章內容")
-                    return array($topic_title, $anonymous, $tags, 'content', $form_data);
+                    return array($topic_title, $anonymous, $tags, implode(',', $form_data), $form_data);
                 }
                 break;
             case 30:


### PR DESCRIPTION
- 問題描述：一般 User 發文後無法再發新文章，除了 Admin 能正常發文。
- 原因：現在文章內容改存成 post_meta, 原本 wp_post table 的 content 欄位都預設存成 "content" 這串相同的 string。BBpress 檢查發現 post content 一樣, 拋出了 Duplicate post error。
- 解決方法：每篇文章的 wp_post content 欄位改存 post_metas 的 concat string, 就不會有 content 重複的問題，也同時保留 bbpress 檢查重複文章的功能。